### PR TITLE
Configurable root urls for OZP backend

### DIFF
--- a/ozp/urls.py
+++ b/ozp/urls.py
@@ -23,15 +23,15 @@ from ozp.decorators.cas_decorators import redirecting_login_required
 from decorator_include import decorator_include
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^api/', decorator_include(redirecting_login_required, 'ozpcenter.urls')),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-    url(r'^iwc-api/', include('ozpiwc.urls')),
-    url(r'^docs/', include('rest_framework_swagger.urls')),
+    url(r'^' + settings.OZP['ROOT_URL'] + 'admin/', include(admin.site.urls)),
+    url(r'^' + settings.OZP['ROOT_URL'] + 'api/', decorator_include(redirecting_login_required, 'ozpcenter.urls')),
+    url(r'^' + settings.OZP['ROOT_URL'] + 'api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^' + settings.OZP['ROOT_URL'] + 'iwc-api/', include('ozpiwc.urls')),
+    url(r'^' + settings.OZP['ROOT_URL'] + 'docs/', include('rest_framework_swagger.urls')),
 
     # CAS
-    url(r'^accounts/login/$', 'cas.views.login', name='login'),
-    url(r'^accounts/logout/$', 'cas.views.logout', name='logout'),
+    url(r'^' + settings.OZP['ROOT_URL'] + 'accounts/login/$', 'cas.views.login', name='login'),
+    url(r'^' + settings.OZP['ROOT_URL'] + 'accounts/logout/$', 'cas.views.logout', name='logout'),
 ]
 
 # in debug, serve the media and static resources with the django web server

--- a/ozpiwc/hal.py
+++ b/ozpiwc/hal.py
@@ -19,7 +19,7 @@ def create_base_structure(request, type='application/json'):
     """
     Creates the initial HAL structure for a given request
     """
-    root_url = request.build_absolute_uri('/')  # flake8: noqa TODO: Is Necessary? - Variable not being used in method
+    root_url = request.build_absolute_uri('/' + settings.OZP['ROOT_URL'])  # flake8: noqa TODO: Is Necessary? - Variable not being used in method
     profile = model_access.get_profile(request.user.username)  # flake8: noqa TODO: Is Necessary? - Variable not being used in method
     data = {
         "_links": {
@@ -60,12 +60,12 @@ def add_hal_structure(data, request, type='application/json'):
 
 
 def get_abs_url_for_profile(request, profile_id):
-    root_url = request.build_absolute_uri('/')
+    root_url = request.build_absolute_uri('/' + settings.OZP['ROOT_URL'])
     return '{0!s}iwc-api/profile/{1!s}/'.format(root_url, profile_id)
 
 
 def get_abs_url_for_iwc(request):
-    root_url = request.build_absolute_uri('/')
+    root_url = request.build_absolute_uri('/' + settings.OZP['ROOT_URL'])
     return '{0!s}iwc-api/'.format(root_url)
 
 

--- a/ozpiwc/hal.py
+++ b/ozpiwc/hal.py
@@ -3,6 +3,7 @@ HAL helpers
 """
 import re
 
+from djangoconf import settings
 import ozpcenter.model_access as model_access
 
 # Constants

--- a/ozpiwc/views.py
+++ b/ozpiwc/views.py
@@ -2,6 +2,7 @@
 """
 import logging
 
+from django.conf import settings
 from rest_framework import status
 from rest_framework import permissions
 from rest_framework import renderers as rf_renderers
@@ -29,7 +30,7 @@ def RootApiView(request):
         return Response('Invalid version requested',
             status=status.HTTP_406_NOT_ACCEPTABLE)
 
-    root_url = request.build_absolute_uri('/')
+    root_url = request.build_absolute_uri('/' + settings.OZP['ROOT_URL'])
     profile = model_access.get_profile(request.user.username)
     data = hal.create_base_structure(request,
         hal.generate_content_type(request.accepted_media_type))


### PR DESCRIPTION
These changes are required to allow the ozp backend to successfully proxy behind a configurable root url.